### PR TITLE
ci: Node 22, OIDC release workflow

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,14 @@ on:
     branches:
       - main
       - next
+permissions:
+  id-token: write   # Required for npm trusted publishing (OIDC)
+  contents: read
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    concurrency: 
+    concurrency:
       group: deploy-${{github.ref}}
       cancel-in-progress: true
     steps:
@@ -18,8 +21,8 @@ jobs:
           fetch-tags: true
       - uses: actions/setup-node@v4
         with:
-          node-version: latest
-          registry-url: "https://registry.npmjs.org"
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
       - run: npm ci
       - run: npm run build
@@ -29,4 +32,3 @@ jobs:
       - run: npx autorel --publish
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
## Summary
- Use Node 22 for release and PR check
- Switch release to npm trusted publishing (OIDC): no `NPM_TOKEN` secret needed
- Add `permissions: id-token: write, contents: read` for OIDC

## After merge
Configure trusted publisher on npm for **brek**: Package → Settings → Trusted publishing → GitHub Actions, workflow `release.yml`. Then you can remove `NPM_TOKEN` from repo secrets.