### PR TITLE
fix: use kizu in integration-tests and add test:int to validate

### DIFF
--- a/integration-tests/test.spec.ts
+++ b/integration-tests/test.spec.ts
@@ -1,4 +1,4 @@
-import {test} from 'hoare';
+import {test} from 'kizu';
 import {writeTypeDef} from '../src/writeTypeDef';
 import {getConfig, loadConfig} from '../src';
 import {readFileSync, unlinkSync} from 'node:fs';

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint": "eslint . --fix",
     "build": "tsc -p tsconfig.build.json",
     "test:int": "BREK_CONFIG_DIR=integration-tests/config BREK_WRITE_DIR=integration-tests/config BREK_LOADERS_FILE_PATH=integration-tests/brek.loaders.js kizu 'integration-tests/**/*.spec.ts'",
-    "validate": "npm run build && npm run lint && npm test"
+    "validate": "npm run build && npm run lint && npm test && npm run test:int"
   },
   "homepage": "https://github.com/mhweiner/brek",
   "keywords": [


### PR DESCRIPTION
**Why release failed**
- `integration-tests/test.spec.ts` still imported `hoare` (we switched src specs to kizu but missed this file).
- PR check only runs `validate` = build + lint + test (no test:int), so integration tests never ran in CI.

**Changes**
- `integration-tests/test.spec.ts`: `hoare` → `kizu`.
- `validate`: add `npm run test:int` so PR CI runs integration tests and would catch this.

`npm run validate` passes locally (unit + int tests).