### PR TITLE
ci: Node 24 in release for npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-tags: true
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'   # npm 11+ required for trusted publishing (OIDC)
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
       - run: npm ci


### PR DESCRIPTION
Trusted publishing requires npm 11.5.1+. Node 22 ships with npm 10, so OIDC was never used and publish 404'd. Use Node 24 in the release job only (ships with npm 11).